### PR TITLE
Big Refactor of Game component

### DIFF
--- a/src/utils/card-filters.js
+++ b/src/utils/card-filters.js
@@ -1,0 +1,20 @@
+export const flippedButUnMatchedCards = cards => {
+  return cards.filter(e => e.flipped && !e.matched);
+}
+
+export const matchedCards = cards => {
+  return cards.filter(e => e.matched);
+}
+
+export const cardsMatch = cards => {
+  const matchList = flippedButUnMatchedCards(cards);
+  return (
+    matchList.length > 1 && 
+    matchList.every(e => e.value === matchList[0].value)
+  );
+}
+
+// TODO: Candidate for memoization?
+export const numCardsFlipped = (cards) => {
+  return cards.filter((card) => card.flipped && !card.matched).length;
+};

--- a/src/utils/card-filters.test.js
+++ b/src/utils/card-filters.test.js
@@ -1,0 +1,104 @@
+import { numCardsFlipped, cardsMatch } from "./card-filters";
+import { CardObj } from "./deck";
+
+describe("numCardsFlipped(cards)", () => {
+  it("counts the number of cards that are flipped", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = numCardsFlipped(cards);
+
+    expect(result).toBe(2);
+  });
+
+  it("ignores cards that are matched in the count", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = numCardsFlipped(cards);
+
+    expect(result).toBe(1);
+  });
+
+  it("returns 0 if cards is empty", () => {
+    const cards = [];
+
+    const result = numCardsFlipped(cards);
+
+    expect(result).toBe(0);
+  });
+});
+
+describe("cardsMatch(cards)", () => {
+  it("returns false when 2 flipped cards DON'T match", () => {
+    const cards = [
+      new CardObj({ flipped: true, value: "5C" }),
+      new CardObj({ flipped: true, value: "7H" }),
+    ];
+    const result = cardsMatch(cards);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns true when 2 flipped cards DO match", () => {
+    const cards = [
+      new CardObj({ flipped: true, value: "5C" }),
+      new CardObj({ flipped: true, value: "5C" }),
+    ];
+    const result = cardsMatch(cards);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when there are less than 2 flipped cards", () => {
+    const cards = [
+      new CardObj({ flipped: false, value: "5C" }),
+      new CardObj({ flipped: true, value: "7H" }),
+    ];
+    const result = cardsMatch(cards);
+
+    expect(result).toBe(false);
+  });
+
+  it("ignores matched cards even if they're flipped (cards match scenario)", () => {
+    const cards = [
+      new CardObj({ flipped: true, value: "7H", matched: true }),
+      new CardObj({ flipped: true, value: "7H", matched: true }),
+      new CardObj({ flipped: true, value: "5C" }),
+      new CardObj({ flipped: true, value: "5C" }),
+    ];
+    const result = cardsMatch(cards);
+
+    expect(result).toBe(true);
+  });
+
+  it("ignores matched cards even if they're flipped (cards don't match scenario)", () => {
+    const cards = [
+      new CardObj({ flipped: true, value: "7H", matched: true }),
+      new CardObj({ flipped: true, value: "7H", matched: true }),
+      new CardObj({ flipped: true, value: "5C" }),
+      new CardObj({ flipped: true, value: "AS" }),
+    ];
+    const result = cardsMatch(cards);
+
+    expect(result).toBe(false);
+  });
+
+  it("ignores unflipped cards when determining if cards are matched", () => {
+    const cards = [
+      new CardObj({ flipped: false, value: "7H" }),
+      new CardObj({ flipped: false, value: "5C" }),
+      new CardObj({ flipped: true, value: "5C" }),
+      new CardObj({ flipped: true, value: "7H" }),
+    ];
+    const result = cardsMatch(cards);
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/utils/deck.js
+++ b/src/utils/deck.js
@@ -1,5 +1,7 @@
 import _ from "lodash";
-import * as deck_module from "./deck"; // this is a workaround so we can mock randomCard in our tests
+
+// this is a workaround so we can mock randomCard, shuffleCards and generateCardPairs in our tests
+import * as deck_module from "./deck";
 
 const suits = ["C", "S", "H", "D"];
 const numbers = [
@@ -18,6 +20,19 @@ const numbers = [
   "A",
 ];
 
+export class CardObj {
+  constructor({ value = "2C", id = 0, flipped = false, matched = false } = {}) {
+    this.value = value;
+    this.id = id;
+    this.flipped = flipped;
+    this.matched = matched;
+  }
+
+  flip() {
+    this.flipped = !this.flipped;
+  }
+}
+
 export const DECK = suits
   .map((suit) => numbers.map((number) => number + suit))
   .flat();
@@ -35,19 +50,25 @@ export const generateCardPairs = (n) => {
   let cards = [];
   for (let i = 0; i < n; i++) {
     // ensure each card has a pair (unless odd and the last card)
-    cards.push({
-      id: i,
-      value:
-        i % 2 === 0
-          ? deck_module.randomCard(cards.map(() => cards.value))
-          : cards[i - 1].value,
-      flipped: false,
-      matched: false,
-    });
+    cards.push(
+      new CardObj({
+        id: i,
+        value:
+          i % 2 === 0
+            ? deck_module.randomCard(cards.map(() => cards.value))
+            : cards[i - 1].value,
+        flipped: false,
+        matched: false,
+      })
+    );
   }
   return cards;
 };
 
 export const shuffleCards = (cards) => {
   return _.shuffle(cards);
+};
+
+export const drawNewCards = (deckSize) => {
+  return deck_module.shuffleCards(deck_module.generateCardPairs(deckSize));
 };

--- a/src/utils/deck.test.js
+++ b/src/utils/deck.test.js
@@ -1,75 +1,12 @@
-import { randomCard, generateCardPairs, DECK, shuffleCards } from "./deck";
+import {
+  randomCard,
+  generateCardPairs,
+  DECK,
+  shuffleCards,
+  drawNewCards,
+  CardObj,
+} from "./deck";
 import _ from "lodash";
-
-const CARD_5C = {
-  id: 0,
-  value: "5C",
-  flipped: false,
-  matched: false,
-};
-
-const TWO_MATCHING_5C_CARDS = [
-  {
-    id: 0,
-    value: "5C",
-    flipped: false,
-    matched: false,
-  },
-  {
-    id: 1,
-    value: "5C",
-    flipped: false,
-    matched: false,
-  },
-];
-
-const TWO_PAIRS_OF_MATCHING_CARDS = [
-  {
-    id: 0,
-    value: "5C",
-    flipped: false,
-    matched: false,
-  },
-  {
-    id: 1,
-    value: "5C",
-    flipped: false,
-    matched: false,
-  },
-  {
-    id: 2,
-    value: "AD",
-    flipped: false,
-    matched: false,
-  },
-  {
-    id: 3,
-    value: "AD",
-    flipped: false,
-    matched: false,
-  },
-];
-
-const ONE_PAIR_MATCHING_ONE_UNMATCHED_CARD = [
-  {
-    id: 0,
-    value: "5C",
-    flipped: false,
-    matched: false,
-  },
-  {
-    id: 1,
-    value: "5C",
-    flipped: false,
-    matched: false,
-  },
-  {
-    id: 2,
-    value: "AD",
-    flipped: false,
-    matched: false,
-  },
-];
 
 describe("randomCard(exclusions=[])", () => {
   it("with no params it does not exclude any cards from the deck", () => {
@@ -117,45 +54,59 @@ describe("randomCard(exclusions=[])", () => {
 
 describe("generateCardPairs(n)", () => {
   it("generates a card with the correct properties (flipped = false, matched = false, value = {value})", () => {
-    const module = require("./deck");
-    jest.spyOn(module, "randomCard").mockReturnValue("5C");
+    jest.spyOn(require("./deck"), "randomCard").mockReturnValue("5C");
+    const expected = [new CardObj({ value: "5C" })];
 
     const result = generateCardPairs(1);
 
-    expect(result).toEqual([CARD_5C]);
+    expect(result).toEqual(expected);
   });
 
   it("generates a pair of matching cards", () => {
-    const module = require("./deck");
-    jest.spyOn(module, "randomCard").mockReturnValueOnce("5C");
+    jest.spyOn(require("./deck"), "randomCard").mockReturnValue("5C");
+    const expected = [
+      new CardObj({ id: 0, value: "5C" }),
+      new CardObj({ id: 1, value: "5C" }),
+    ];
 
     const result = generateCardPairs(2);
 
-    expect(result).toEqual(TWO_MATCHING_5C_CARDS);
+    expect(result).toEqual(expected);
   });
 
   it("generates a pair of matching cards", () => {
-    const module = require("./deck");
     jest
-      .spyOn(module, "randomCard")
+      .spyOn(require("./deck"), "randomCard")
       .mockReturnValueOnce("5C")
       .mockReturnValueOnce("AD");
 
+    const expected = [
+      new CardObj({ id: 0, value: "5C" }),
+      new CardObj({ id: 1, value: "5C" }),
+      new CardObj({ id: 2, value: "AD" }),
+      new CardObj({ id: 3, value: "AD" }),
+    ];
+
     const result = generateCardPairs(4);
 
-    expect(result).toEqual(TWO_PAIRS_OF_MATCHING_CARDS);
+    expect(result).toEqual(expected);
   });
 
   it("generates a non-matching pair when numCards is odd", () => {
-    const module = require("./deck");
     jest
-      .spyOn(module, "randomCard")
+      .spyOn(require("./deck"), "randomCard")
       .mockReturnValueOnce("5C")
       .mockReturnValueOnce("AD");
 
     const result = generateCardPairs(3);
 
-    expect(result).toEqual(ONE_PAIR_MATCHING_ONE_UNMATCHED_CARD);
+    const expected = [
+      new CardObj({ id: 0, value: "5C" }),
+      new CardObj({ id: 1, value: "5C" }),
+      new CardObj({ id: 2, value: "AD" }),
+    ];
+
+    expect(result).toEqual(expected);
   });
 
   it("all cards have matched and flipped set to false", () => {
@@ -178,7 +129,40 @@ describe("generateCardPairs(n)", () => {
 describe("shuffleCards(cards)", () => {
   it("should call lodash's shuffle cards method", () => {
     jest.spyOn(_, "shuffle");
-    shuffleCards(TWO_PAIRS_OF_MATCHING_CARDS);
+    const cards = [
+      new CardObj({ id: 0, value: "5C" }),
+      new CardObj({ id: 1, value: "5C" }),
+      new CardObj({ id: 2, value: "AD" }),
+      new CardObj({ id: 3, value: "AD" }),
+    ];
+
+    shuffleCards(cards);
     expect(_.shuffle).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("drawNewCards(deckSize)", () => {
+  it("should produce a deck of length = deckSize", () => {
+    const result = drawNewCards(9);
+
+    expect(result.length).toBe(9);
+  });
+
+  it("should produce cards that have been shuffled", () => {
+    jest.spyOn(require("./deck"), "shuffleCards");
+
+    drawNewCards(9);
+
+    expect(shuffleCards).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call to generate pairs", () => {
+    const deckSize = 9;
+    jest.spyOn(require("./deck"), "generateCardPairs");
+
+    drawNewCards(deckSize);
+
+    expect(generateCardPairs).toHaveBeenCalledTimes(1);
+    expect(generateCardPairs).toHaveBeenCalledWith(deckSize);
   });
 });

--- a/src/utils/game-engine.js
+++ b/src/utils/game-engine.js
@@ -1,19 +1,39 @@
-const _flippedButUnMatchedCards = cards => {
-  return cards.filter(e => e.flipped && !e.matched);
-}
+import _ from "lodash";
+import { numCardsFlipped, matchedCards } from "./card-filters";
 
-const _matchedCards = cards => {
-  return cards.filter(e => e.matched);
-}
+export const flipCardAtIndex = (cards, index) => {
+  let clone = _.cloneDeep(cards);
+  let card = clone[index];
+  if (!card.flipped && !card.matched && numCardsFlipped(clone) < 2) {
+    card.flip();
+  }
+  return clone;
+};
 
-export const cardsMatch = cards => {
-  const matchList = _flippedButUnMatchedCards(cards);
-  return (
-    matchList.length > 1 && 
-    matchList.every(e => e.value === matchList[0].value)
-  );
-}
+// for successful card matches
+export const setFlippedCardsToMatched = (cards) => {
+  let clone = _.cloneDeep(cards);
+  // all flipped cards are a match, so we can take this shortcut
+  clone.forEach((e) => (e.matched = e.flipped));
+  return clone;
+};
 
-export const allPairsMatched = cards => {
-  return _matchedCards(cards).length === Math.floor(cards.length / 2) * 2
-}
+// for unsuccessful card matches
+export const unflipUnmatchedCards = (cards) => {
+  let clone = _.cloneDeep(cards);
+  // only unflip the non-matched cards
+  clone.forEach((e) => (e.flipped = e.matched ? e.flipped : false));
+  return clone;
+};
+
+// for determining a winning game
+export const allPairsMatched = (cards) => {
+  return matchedCards(cards).length === Math.floor(cards.length / 2) * 2;
+};
+
+// Note: this does allow for setting arbitrary options on cards, but that's
+// ok for now since it allows for the expansion of card properties as we experiment
+export const setAllCardsProperties = (cards, options = {}) => {
+  let clone = _.cloneDeep(cards);
+  return clone.map((card) => Object.assign(card, options));
+};

--- a/src/utils/game-engine.test.js
+++ b/src/utils/game-engine.test.js
@@ -1,92 +1,17 @@
-import { cardsMatch, allPairsMatched } from "./game-engine";
-
-const CARD_TEMPLATE = {
-  id: 0,
-  value: "2C",
-  flipped: false,
-  matched: false,
-}
-
-function createCard(options = {}) {
-  return { ...CARD_TEMPLATE, ...options };
-};
-
-describe("cardsMatch(cards)", () => {
-  it("returns false when 2 flipped cards DON'T match", () => {
-    const cards = [
-      createCard( {flipped: true, value: "5C"} ), 
-      createCard( {flipped: true, value: "7H"} )
-    ];
-    const result = cardsMatch(cards);
-
-    expect(result).toBe(false);
-  })
-
-  it("returns true when 2 flipped cards DO match", () => {
-    const cards = [
-      createCard( {flipped: true, value: "5C"} ), 
-      createCard( {flipped: true, value: "5C"} )
-    ];
-    const result = cardsMatch(cards);
-
-    expect(result).toBe(true);
-  });
-
-  it("returns false when there are less than 2 flipped cards", () => {
-    const cards = [
-      createCard( {flipped: false, value: "5C"} ), 
-      createCard( {flipped: true, value: "7H"} )
-    ];
-    const result = cardsMatch(cards);
-
-    expect(result).toBe(false);
-  });
-
-  it("ignores matched cards even if they're flipped (cards match scenario)", () => {
-    const cards = [
-      createCard( {flipped: true, value: "7H", matched: true } ), 
-      createCard( {flipped: true, value: "7H", matched: true } ), 
-      createCard( {flipped: true, value: "5C"} ), 
-      createCard( {flipped: true, value: "5C"} )
-
-    ];
-    const result = cardsMatch(cards);
-
-    expect(result).toBe(true);
-  });
-
-  it("ignores matched cards even if they're flipped (cards don't match scenario)", () => {
-    const cards = [
-      createCard( {flipped: true, value: "7H", matched: true } ), 
-      createCard( {flipped: true, value: "7H", matched: true } ), 
-      createCard( {flipped: true, value: "5C"} ), 
-      createCard( {flipped: true, value: "AS"} )
-
-    ];
-    const result = cardsMatch(cards);
-
-    expect(result).toBe(false);
-  });
-
-  it("ignores unflipped cards when determining if cards are matched", () => {
-    const cards = [
-      createCard( {flipped: false, value: "7H"} ), 
-      createCard( {flipped: false, value: "5C"} ), 
-      createCard( {flipped: true, value: "5C"} ), 
-      createCard( {flipped: true, value: "7H"} )
-
-    ];
-    const result = cardsMatch(cards);
-
-    expect(result).toBe(false);
-  });
-});
+import {
+  allPairsMatched,
+  setAllCardsProperties,
+  setFlippedCardsToMatched,
+  flipCardAtIndex,
+  unflipUnmatchedCards,
+} from "./game-engine";
+import { CardObj } from "./deck";
 
 describe("allPairsMatched(cards)", () => {
   it("returns true when every card in collection has match property of true", () => {
     const cards = [
-      createCard( {flipped: true, value: "7H", matched: true } ), 
-      createCard( {flipped: true, value: "7H", matched: true } ), 
+      new CardObj({ flipped: true, value: "7H", matched: true }),
+      new CardObj({ flipped: true, value: "7H", matched: true }),
     ];
 
     const result = allPairsMatched(cards);
@@ -96,8 +21,8 @@ describe("allPairsMatched(cards)", () => {
 
   it("returns false when not every card in collection has match property of true (length of collection is even)", () => {
     const cards = [
-      createCard( {flipped: true, value: "7H", matched: false } ), 
-      createCard( {flipped: true, value: "7H", matched: true } ), 
+      new CardObj({ flipped: true, value: "7H", matched: false }),
+      new CardObj({ flipped: true, value: "7H", matched: true }),
     ];
 
     const result = allPairsMatched(cards);
@@ -107,9 +32,9 @@ describe("allPairsMatched(cards)", () => {
 
   it("returns true if all but one card in collection has match property of true AND length of collection is odd", () => {
     const cards = [
-      createCard( {flipped: true, value: "2D", matched: false } ), 
-      createCard( {flipped: true, value: "7H", matched: true } ), 
-      createCard( {flipped: true, value: "7H", matched: true } ), 
+      new CardObj({ flipped: true, value: "2D", matched: false }),
+      new CardObj({ flipped: true, value: "7H", matched: true }),
+      new CardObj({ flipped: true, value: "7H", matched: true }),
     ];
 
     const result = allPairsMatched(cards);
@@ -119,34 +44,372 @@ describe("allPairsMatched(cards)", () => {
 
   it("returns true if all but one card in collection has match property of true AND length of collection is odd (multiple pairs of matching)", () => {
     const cards = [
-      createCard( {flipped: true, value: "2D", matched: false } ), 
-      createCard( {flipped: true, value: "7H", matched: true } ), 
-      createCard( {flipped: true, value: "7H", matched: true } ),
-      createCard( {flipped: true, value: "AS", matched: true } ), 
-      createCard( {flipped: true, value: "AS", matched: true } ),
-      createCard( {flipped: true, value: "QD", matched: true } ), 
-      createCard( {flipped: true, value: "QD", matched: true } ), 
+      new CardObj({ flipped: true, value: "2D", matched: false }),
+      new CardObj({ flipped: true, value: "7H", matched: true }),
+      new CardObj({ flipped: true, value: "7H", matched: true }),
+      new CardObj({ flipped: true, value: "AS", matched: true }),
+      new CardObj({ flipped: true, value: "AS", matched: true }),
+      new CardObj({ flipped: true, value: "QD", matched: true }),
+      new CardObj({ flipped: true, value: "QD", matched: true }),
     ];
 
     const result = allPairsMatched(cards);
 
     expect(result).toBe(true);
   });
-  
+
   it("ignores whether or not cards have been flipped when checking for matches", () => {
     const cards = [
-      createCard( {flipped: false, value: "2D", matched: false } ), 
-      createCard( {flipped: false, value: "7H", matched: true } ), 
-      createCard( {flipped: true, value: "7H", matched: true } ),
-      createCard( {flipped: false, value: "AS", matched: true } ), 
-      createCard( {flipped: true, value: "AS", matched: true } ),
-      createCard( {flipped: false, value: "QD", matched: true } ), 
-      createCard( {flipped: true, value: "QD", matched: true } ), 
+      new CardObj({ flipped: false, value: "2D", matched: false }),
+      new CardObj({ flipped: false, value: "7H", matched: true }),
+      new CardObj({ flipped: true, value: "7H", matched: true }),
+      new CardObj({ flipped: false, value: "AS", matched: true }),
+      new CardObj({ flipped: true, value: "AS", matched: true }),
+      new CardObj({ flipped: false, value: "QD", matched: true }),
+      new CardObj({ flipped: true, value: "QD", matched: true }),
     ];
 
     const result = allPairsMatched(cards);
 
     expect(result).toBe(true);
   });
-  
+});
+
+describe("setFlippedCardsToMatched", () => {
+  it("set only the cards that are flipped to matched", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = setFlippedCardsToMatched(cards);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("cards that are matched remain flipped", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = setFlippedCardsToMatched(cards);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("does nothing if none of the cards are flipped", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = setFlippedCardsToMatched(cards);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("pure function - does not modify passed arguments", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const copyOfOriginal = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    setFlippedCardsToMatched(cards);
+
+    expect(cards).toEqual(copyOfOriginal);
+  });
+});
+
+describe("setAllCardsProperties(cards, options={})", () => {
+  it("does nothing when empty options are passed in", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = setAllCardsProperties(cards, {});
+
+    expect(result).toEqual(cards);
+  });
+
+  it("can set all cards to unflipped", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = setAllCardsProperties(cards, { flipped: false });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("Pure Function - does not modify passed arguments", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const copyOfOriginal = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    setAllCardsProperties(cards, { flipped: false, matched: false });
+
+    expect(cards).toEqual(copyOfOriginal);
+  });
+
+  it("can set all cards to matched", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: true }),
+    ];
+
+    const result = setAllCardsProperties(cards, { matched: true });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("can set more than one property at once (e.g. flipped and matched)", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+    ];
+
+    const result = setAllCardsProperties(cards, {
+      flipped: true,
+      matched: true,
+    });
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("flipCardAtIndex(cards, index)", () => {
+  it("sets flipped property to true for card at index", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = flipCardAtIndex(cards, 1);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("won't flip a card if it has already been flipped (i.e. flipped = true)", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = flipCardAtIndex(cards, 0);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("won't flip a card if it is matched already (i.e. matched = true)", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = flipCardAtIndex(cards, 0);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("won't flip a card if more than 2 un-matchd cards are already flipped", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = flipCardAtIndex(cards, 2);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("ignores matched cards and will flip if less than 2 unmatched cards are flipped", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+    ];
+
+    const result = flipCardAtIndex(cards, 2);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("Pure function - does not modify the passed arguments", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const copyOfOriginal = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    flipCardAtIndex(cards, 2);
+
+    expect(cards).toEqual(copyOfOriginal);
+  });
+
+  it("throws an error if index is out of range", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    expect(() => flipCardAtIndex(cards, 3)).toThrow(Error);
+  });
+});
+
+describe("unflipUnmatchedCards(cards)", () => {
+  it("unflips any cards that are not currently matching (i.e. matched=true)", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const result = unflipUnmatchedCards(cards);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("ignores matched cards", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: true }),
+    ];
+
+    const expected = [
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: true, matched: true }),
+      new CardObj({ value: "2C", flipped: false, matched: true }),
+    ];
+
+    const result = unflipUnmatchedCards(cards);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("Pure function - does not modify passed arguments", () => {
+    const cards = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    const copyOfOriginal = [
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: true, matched: false }),
+      new CardObj({ value: "2C", flipped: false, matched: false }),
+    ];
+
+    unflipUnmatchedCards(cards);
+
+    expect(cards).toEqual(copyOfOriginal);
+  });
 });


### PR DESCRIPTION
As I started writing tests for the game component, I noticed that it felt cumbersome and the logic between maintaining the component's state and the game's state was really intermingled. For example, clicking a card triggers a bunch of interaction with the state of the card game (e.g. has the player won the game, does this card match another flipped card), but has nothing to do with the rendering of the component. When testing the rendering, it was hard to see the observed state, so I pulled it out to make it more testable.

For the future: I think it might be good to pull a lot of these utility functions into a single GameState class or object. Interacting with the current API feels uninuitive, and I'd like to be able to just say `game.flipCard(index)` and watch for changes to game.hasWon or something like that.