### PR TITLE
Refactor the card match and card flip properties

### DIFF
--- a/src/components/card.js
+++ b/src/components/card.js
@@ -1,5 +1,6 @@
 import React from "react";
 import "./card.css";
+import { CARD_STATES } from "../utils/deck";
 
 export default function Card(props) {
   const flipCard = (e) => {
@@ -11,7 +12,7 @@ export default function Card(props) {
   return (
     <div
       onClick={flipCard}
-      className={["card", props.flipped ? "isFlipped" : ""].join(" ")}
+      className={["card", props.state !== CARD_STATES.unflipped ? "isFlipped" : ""].join(" ")}
     >
       <div className="front">
         <img

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -2,14 +2,13 @@ import React, { Suspense, lazy, useEffect, useState } from "react";
 import "./game.css";
 import _ from "lodash";
 import fireConfetti from "../utils/confetti-cannon";
-import { shuffleCards, drawNewCards } from "../utils/deck";
+import { shuffleCards, drawNewCards, CARD_STATES } from "../utils/deck";
 import { cardsMatch, numCardsFlipped } from "../utils/card-filters";
 import {
   allPairsMatched,
   flipCardAtIndex,
-  setAllCardsProperties,
-  setFlippedCardsToMatched,
-  unflipUnmatchedCards,
+  transitionState,
+  unflipAll
 } from "../utils/game-engine";
 import { useAuth0 } from "./../react-auth0-spa";
 
@@ -30,7 +29,7 @@ const Game = (props) => {
   };
 
   const handleStartOver = () => {
-    setCards(setAllCardsProperties({ flipped: false }));
+    setCards(unflipAll(cards));
     // wait for card flip animation
     _.delay(() => {
       setCards(drawNewCards(props.deckSize));
@@ -40,15 +39,15 @@ const Game = (props) => {
   };
 
   const handleUnflip = () => {
-    setCards(setAllCardsProperties({ flipped: false }));
+    setCards(unflipAll(cards));
   };
 
   const checkForMatches = () => {
     if (cardsMatch(cards)) {
-      setCards(setFlippedCardsToMatched(cards));
+      setCards(transitionState(cards, CARD_STATES.flipped, CARD_STATES.matched));
     } else if (numCardsFlipped(cards) > 1) {
       _.delay(() => {
-        setCards(unflipUnmatchedCards(cards));
+        setCards(transitionState(cards, CARD_STATES.flipped, CARD_STATES.unflipped));
       }, 1000);
     }
   };
@@ -89,7 +88,7 @@ const Game = (props) => {
               key={card.id}
               index={i}
               value={card.value}
-              flipped={card.flipped}
+              state={card.state}
               onClicked={handleCardClick}
             />
           ))}

--- a/src/utils/card-filters.js
+++ b/src/utils/card-filters.js
@@ -1,20 +1,26 @@
-export const flippedButUnMatchedCards = cards => {
-  return cards.filter(e => e.flipped && !e.matched);
+import { CARD_STATES } from "./deck";
+
+export const filterCardsByState = (cards, state) => {
+  return cards.filter(card => card.state === state);
+}
+
+export const flippedCards = cards => {
+  return filterCardsByState(cards, CARD_STATES.flipped);
 }
 
 export const matchedCards = cards => {
-  return cards.filter(e => e.matched);
+  return filterCardsByState(cards, CARD_STATES.matched);
 }
 
 export const cardsMatch = cards => {
-  const matchList = flippedButUnMatchedCards(cards);
+  const matchList = flippedCards(cards);
   return (
     matchList.length > 1 && 
-    matchList.every(e => e.value === matchList[0].value)
+    matchList.every(card => card.value === matchList[0].value)
   );
 }
 
 // TODO: Candidate for memoization?
 export const numCardsFlipped = (cards) => {
-  return cards.filter((card) => card.flipped && !card.matched).length;
+  return flippedCards(cards).length;
 };

--- a/src/utils/card-filters.test.js
+++ b/src/utils/card-filters.test.js
@@ -1,24 +1,12 @@
 import { numCardsFlipped, cardsMatch } from "./card-filters";
-import { CardObj } from "./deck";
+import { CardObj, CARD_STATES } from "./deck";
 
 describe("numCardsFlipped(cards)", () => {
-  it("counts the number of cards that are flipped", () => {
+  it("counts only cards in the flipped state", () => {
     const cards = [
-      new CardObj({ value: "2C", flipped: true, matched: false }),
-      new CardObj({ value: "2C", flipped: true, matched: false }),
-      new CardObj({ value: "2C", flipped: false, matched: false }),
-    ];
-
-    const result = numCardsFlipped(cards);
-
-    expect(result).toBe(2);
-  });
-
-  it("ignores cards that are matched in the count", () => {
-    const cards = [
-      new CardObj({ value: "2C", flipped: true, matched: false }),
-      new CardObj({ value: "2C", flipped: true, matched: true }),
-      new CardObj({ value: "2C", flipped: false, matched: false }),
+      new CardObj({ value: "2C", state: CARD_STATES.unflipped }),
+      new CardObj({ value: "2C", state: CARD_STATES.flipped }),
+      new CardObj({ value: "2C", state: CARD_STATES.matched }),
     ];
 
     const result = numCardsFlipped(cards);
@@ -38,8 +26,8 @@ describe("numCardsFlipped(cards)", () => {
 describe("cardsMatch(cards)", () => {
   it("returns false when 2 flipped cards DON'T match", () => {
     const cards = [
-      new CardObj({ flipped: true, value: "5C" }),
-      new CardObj({ flipped: true, value: "7H" }),
+      new CardObj({ value: "5C", state: CARD_STATES.flipped }),
+      new CardObj({ value: "7H", state: CARD_STATES.flipped }),
     ];
     const result = cardsMatch(cards);
 
@@ -48,8 +36,8 @@ describe("cardsMatch(cards)", () => {
 
   it("returns true when 2 flipped cards DO match", () => {
     const cards = [
-      new CardObj({ flipped: true, value: "5C" }),
-      new CardObj({ flipped: true, value: "5C" }),
+      new CardObj({ value: "5C", state: CARD_STATES.flipped }),
+      new CardObj({ value: "5C", state: CARD_STATES.flipped }),
     ];
     const result = cardsMatch(cards);
 
@@ -58,8 +46,8 @@ describe("cardsMatch(cards)", () => {
 
   it("returns false when there are less than 2 flipped cards", () => {
     const cards = [
-      new CardObj({ flipped: false, value: "5C" }),
-      new CardObj({ flipped: true, value: "7H" }),
+      new CardObj({ value: "5C", state: CARD_STATES.unflipped }),
+      new CardObj({ value: "5C", state: CARD_STATES.flipped }),
     ];
     const result = cardsMatch(cards);
 
@@ -68,10 +56,10 @@ describe("cardsMatch(cards)", () => {
 
   it("ignores matched cards even if they're flipped (cards match scenario)", () => {
     const cards = [
-      new CardObj({ flipped: true, value: "7H", matched: true }),
-      new CardObj({ flipped: true, value: "7H", matched: true }),
-      new CardObj({ flipped: true, value: "5C" }),
-      new CardObj({ flipped: true, value: "5C" }),
+      new CardObj({ value: "5C", state: CARD_STATES.matched }),
+      new CardObj({ value: "5C", state: CARD_STATES.matched }),
+      new CardObj({ value: "7H", state: CARD_STATES.flipped }),
+      new CardObj({ value: "7H", state: CARD_STATES.flipped }),
     ];
     const result = cardsMatch(cards);
 
@@ -80,10 +68,10 @@ describe("cardsMatch(cards)", () => {
 
   it("ignores matched cards even if they're flipped (cards don't match scenario)", () => {
     const cards = [
-      new CardObj({ flipped: true, value: "7H", matched: true }),
-      new CardObj({ flipped: true, value: "7H", matched: true }),
-      new CardObj({ flipped: true, value: "5C" }),
-      new CardObj({ flipped: true, value: "AS" }),
+      new CardObj({ value: "5C", state: CARD_STATES.matched }),
+      new CardObj({ value: "5C", state: CARD_STATES.matched }),
+      new CardObj({ value: "7H", state: CARD_STATES.flipped }),
+      new CardObj({ value: "AS", state: CARD_STATES.flipped }),
     ];
     const result = cardsMatch(cards);
 
@@ -92,10 +80,10 @@ describe("cardsMatch(cards)", () => {
 
   it("ignores unflipped cards when determining if cards are matched", () => {
     const cards = [
-      new CardObj({ flipped: false, value: "7H" }),
-      new CardObj({ flipped: false, value: "5C" }),
-      new CardObj({ flipped: true, value: "5C" }),
-      new CardObj({ flipped: true, value: "7H" }),
+      new CardObj({ value: "5C", state: CARD_STATES.unflipped }),
+      new CardObj({ value: "5C", state: CARD_STATES.flipped }),
+      new CardObj({ value: "7H", state: CARD_STATES.flipped }),
+      new CardObj({ value: "7H", state: CARD_STATES.unflipped }),
     ];
     const result = cardsMatch(cards);
 

--- a/src/utils/deck.js
+++ b/src/utils/deck.js
@@ -56,7 +56,7 @@ export const generateCardPairs = (n) => {
         id: i,
         value:
           i % 2 === 0
-            ? deck_module.randomCard(cards.map(() => cards.value))
+            ? deck_module.randomCard(cards.map((card) => card.value))
             : cards[i - 1].value,
         state: CARD_STATES.unflipped
       })

--- a/src/utils/deck.js
+++ b/src/utils/deck.js
@@ -20,16 +20,17 @@ const numbers = [
   "A",
 ];
 
+export const CARD_STATES = {
+  unflipped: "unflipped",
+  flipped: "flipped",
+  matched: "matched"
+}
+
 export class CardObj {
-  constructor({ value = "2C", id = 0, flipped = false, matched = false } = {}) {
+  constructor({ value = "2C", id = 0, state = CARD_STATES.unflipped } = {}) {
     this.value = value;
     this.id = id;
-    this.flipped = flipped;
-    this.matched = matched;
-  }
-
-  flip() {
-    this.flipped = !this.flipped;
+    this.state = state;
   }
 }
 
@@ -57,8 +58,7 @@ export const generateCardPairs = (n) => {
           i % 2 === 0
             ? deck_module.randomCard(cards.map(() => cards.value))
             : cards[i - 1].value,
-        flipped: false,
-        matched: false,
+        state: CARD_STATES.unflipped
       })
     );
   }

--- a/src/utils/game-engine.js
+++ b/src/utils/game-engine.js
@@ -1,39 +1,29 @@
 import _ from "lodash";
 import { numCardsFlipped, matchedCards } from "./card-filters";
+import { CARD_STATES } from "./deck";
 
 export const flipCardAtIndex = (cards, index) => {
   let clone = _.cloneDeep(cards);
   let card = clone[index];
-  if (!card.flipped && !card.matched && numCardsFlipped(clone) < 2) {
-    card.flip();
+  if (card.state === CARD_STATES.unflipped && numCardsFlipped(clone) < 2) {
+    card.state = CARD_STATES.flipped;
   }
   return clone;
 };
 
-// for successful card matches
-export const setFlippedCardsToMatched = (cards) => {
+export const transitionState = (cards, currState, newState) => {
   let clone = _.cloneDeep(cards);
-  // all flipped cards are a match, so we can take this shortcut
-  clone.forEach((e) => (e.matched = e.flipped));
+  clone.forEach(card => card.state = (card.state === currState ? newState : card.state));
   return clone;
-};
+}
 
-// for unsuccessful card matches
-export const unflipUnmatchedCards = (cards) => {
+export const unflipAll = cards => {
   let clone = _.cloneDeep(cards);
-  // only unflip the non-matched cards
-  clone.forEach((e) => (e.flipped = e.matched ? e.flipped : false));
+  clone.forEach(card => card.state = CARD_STATES.unflipped);
   return clone;
-};
+}
 
 // for determining a winning game
 export const allPairsMatched = (cards) => {
   return matchedCards(cards).length === Math.floor(cards.length / 2) * 2;
-};
-
-// Note: this does allow for setting arbitrary options on cards, but that's
-// ok for now since it allows for the expansion of card properties as we experiment
-export const setAllCardsProperties = (cards, options = {}) => {
-  let clone = _.cloneDeep(cards);
-  return clone.map((card) => Object.assign(card, options));
 };


### PR DESCRIPTION
**Check out #8 for the first step of this refactor**

I noticed during test writing that having two separate properties for
`card.flipped` and `card.matched` was creating a lot of duplicate work.
For example, tests for `setFlippedCardsToMatched(cards)` required
checking for permutations where matched was true but it needed to be
ignored from the set of flipped cards.

After some experimenting, I realized we have 3 distinct states:
1) Unflipped (or unselected)
2) Flipped (or currently selected)
3) Matched

This allows for a much cleaner implementation, a little code reuse and
not needing to maintain quite as many tests!